### PR TITLE
Break out of handler when user is found

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -22,6 +22,7 @@ app.get("/users/:id", (req, res) => {
     const haystack = demoData.users[needle];
     if (haystack.id === idx) {
       res.status(200).json(haystack);
+      return;
     }
   }
   res.status(400).json({ msg: "User not found" });


### PR DESCRIPTION
When the user is successfully found, the handler needs to return so that it doesn’t try to respond with the 400 after it’s already responded.